### PR TITLE
Use v2 signing via truelayer-signing lib

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,50 +1,35 @@
-const JWS = require('jws');
-
-const createJws = (certificateId, payload, privateKey) => JWS.sign({
-  header: {
-    alg: 'ES512',
-    kid: certificateId,
-  },
-  payload,
-  privateKey,
-});
-
-const detachContent = jws => {
-  const parts = jws.split('.');
-  return `${parts[0]}..${parts[2]}`;
-};
+const tlSigning = require('truelayer-signing');
 
 const addTlSignatureToRequest = context => {
-  const payload = context.request.getBodyText();
   const jwsIsRequired = context.request.getEnvironmentVariable('REQUIRE_JWS') === true;
-
   if (!jwsIsRequired) {
     console.log('no signing needed because the REQUIRE_JWS environment variable is either missing or !== true');
     return;
   }
 
-  // we only need signing for requests with a body
-  if (!payload) {
-    console.log('no signing needed because there is no payload');
-    return false;
-  }
-
   const certificateId = context.request.getEnvironmentVariable('CERTIFICATE_ID');
-
   if (!certificateId) {
     throw new Error('Missing required `CERTIFICATE_ID` environment variable.');
   }
 
   const privateKey = context.request.getEnvironmentVariable('PRIVATE_KEY');
-
   if (!privateKey) {
     throw new Error('Missing required `PRIVATE_KEY` environment variable.');
   }
 
-  const jws = createJws(certificateId, payload, privateKey);
-  const jwsWithDetachedContent = detachContent(jws);
-  context.request.setHeader('X-Tl-Signature', jwsWithDetachedContent);
+  let idempotencyKey = context.request.getHeader("Idempotency-Key");
+
+  let v2Signature = tlSigning.sign({
+    kid: certificateId,
+    privateKeyPem: privateKey,
+    method: context.request.getMethod(),
+    path: new URL(context.request.getUrl()).pathname,
+    body: context.request.getBodyText(),
+    headers: idempotencyKey ? { "Idempotency-Key": idempotencyKey } : {},
+  });
+  context.request.setHeader('Tl-Signature', v2Signature);
 }
+
 
 module.exports.requestHooks = [
   addTlSignatureToRequest

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "insomna-plugin-jws-by-tl",
-  "version": "0.0.1",
+  "name": "insomnia-plugin-jws-by-truelayer",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -16,6 +16,11 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "js-base64": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
+      "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
     },
     "jwa": {
       "version": "2.0.0",
@@ -40,6 +45,15 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "truelayer-signing": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/truelayer-signing/-/truelayer-signing-0.1.0.tgz",
+      "integrity": "sha512-BLGSgXJVo/DJ5yS37evuj6za047pLz6CHqsMdbrap5/KXz5XVjeNoUxZ3QmpPKwo7biJltJMJV1+v9xa8d95sg==",
+      "requires": {
+        "js-base64": "^3.7.2",
+        "jws": "^4.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "description": "Adds a JSON Web Signature header to HTTP requests by using the request body as detached payload."
   },
   "dependencies": {
-    "jws": "^4.0.0"
+    "truelayer-signing": "^0.1.0"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
Use [truelayer-signing](https://github.com/TrueLayer/truelayer-signing/tree/main/javascript) to produce v2 full request `Tl-Signature` headers.

These will be required for the new payments gateway API. They are already supported by paydirect-api & payouts-api.

## Install from branch
You can use this plugin direct from the branch. Go to your insomnia plugins dir
> * MacOS: `~/Library/Application Support/Insomnia/plugins/` (escaped version: `~/Library/Application\ Support/Insomnia/plugins/`)
> * Windows: `%APPDATA%\Insomnia\plugins\`
> * Linux: `$XDG_CONFIG_HOME/Insomnia/plugins/` or `~/.config/Insomnia/plugins/`

Can checkout the `v2-signing` code:
```sh
git clone -b v2-signing https://github.com/TrueLayer/insomnia-plugin-jws
cd insomnia-plugin-jws
npm install
```

Now you can use the new version before it's published to npm.
